### PR TITLE
Move meeting time one hour ahead

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ### Weekly meetings
 
-The team meets every Tuesday at 16:00-16:30 (4:00-4:30 PM) UTC.
+The team meets every Tuesday at 17:00-18:00 (5:00-6:00 PM) UTC.
 
 Meetings are open at https://meet.jit.si/moderated/90cbbb56c02272cad4a5d9c48382eb9992de4f691c82e175ead9da4e7d967009


### PR DESCRIPTION
Previous time was overlapping with the [Wasm CG meeting](https://github.com/WebAssembly/meetings/blob/main/main/CG-template.md)